### PR TITLE
Add rustc-dep-of-std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,13 @@ readme = "README.md"
 documentation = "https://docs.rs/wasi"
 
 [dependencies]
+# When built as part of libstd
+compiler_builtins = { version = "0.1", optional = true }
+core = { version = "1.0", optional = true, package = "rustc-std-workspace-core" }
+
+[features]
+# Unstable feature to support being a libstd dependency
+rustc-dep-of-std = ["compiler_builtins", "core"]
 
 [badges]
 maintenance = { status = "experimental" }


### PR DESCRIPTION
It will allow `wasi` to be used as a `libstd` dependency. See this [comment](https://github.com/rust-lang/rust/pull/62082#issuecomment-521399966).