### PR TITLE
Allow activating wit-bindgen/macros

### DIFF
--- a/crates/wasip3/Cargo.toml
+++ b/crates/wasip3/Cargo.toml
@@ -23,6 +23,7 @@ http-compat = [
     "dep:thiserror",
     "async-spawn",
 ]
+wit-bindgen-macros = ["wit-bindgen/macros"]
 
 [dependencies]
 # NB: async bindings require `std` right now so this doesn't optionally disable


### PR DESCRIPTION
Enables accessing `wit_bindgen::generate!` from the re-export.