### PR TITLE
Fix WASI P3 spec references in README

### DIFF
--- a/crates/wasip3/README.md
+++ b/crates/wasip3/README.md
@@ -18,12 +18,12 @@ This crate contains bindings for [WASIp3](https://github.com/WebAssembly/WASI)
 APIs for the worlds:
 
 * [`wasi:cli/command`]
-* [`wasi:http/proxy`]
+* [`wasi:http/service`]
 
 This crate is procedurally generated from [WIT] files using [`wit-bindgen`].
 
-[`wasi:cli/command`]: https://github.com/WebAssembly/wasi-cli
-[`wasi:http/proxy`]: https://github.com/WebAssembly/wasi-http
+[`wasi:cli/command`]: https://github.com/WebAssembly/WASI/tree/main/proposals/cli
+[`wasi:http/service`]: https://github.com/WebAssembly/WASI/tree/main/proposals/http
 [WIT]: https://component-model.bytecodealliance.org/design/wit.html
 [`wit-bindgen`]: https://github.com/bytecodealliance/wit-bindgen
 [components]: https://component-model.bytecodealliance.org/

--- a/crates/wasip3/src/lib.rs
+++ b/crates/wasip3/src/lib.rs
@@ -6,7 +6,7 @@
 //! such as:
 //!
 //! * [`wasi:cli/command`]
-//! * [`wasi:http/proxy`]
+//! * [`wasi:http/service`]
 //!
 //! This crate is procedurally generated with the [`wit-bindgen`] bindings
 //! generator. Note that generated code is published to crates.io to slim this
@@ -133,8 +133,8 @@
 //! - [`wasi::http::proxy::export!`](crate::http::proxy::export)
 //!
 //! [worlds]: https://component-model.bytecodealliance.org/design/worlds.html
-//! [`wasi:cli/command`]: https://github.com/WebAssembly/wasi-cli/
-//! [`wasi:http/proxy`]: https://github.com/WebAssembly/wasi-http
+//! [`wasi:cli/command`]: https://github.com/WebAssembly/WASI/tree/main/proposals/cli
+//! [`wasi:http/service`]: https://github.com/WebAssembly/WASI/tree/main/proposals/http
 //! [`wasi:cli/stdio`]: https://github.com/WebAssembly/wasi-cli/blob/main/wit-0.3.0-draft/stdio.wit
 //! [`wit-bindgen`]: https://github.com/bytecodealliance/wit-bindgen/
 //! [Component Model]: https://component-model.bytecodealliance.org/


### PR DESCRIPTION
The `wasip3` crate README references the P2 HTTP world, and links to archived P2 specs.  These are highly visible on https://docs.rs/wasip3/latest/wasip3/ so I reckon they're worth a quick tweak!
