### PR TITLE
Remove redundant casts

### DIFF
--- a/crates/wasip2/src/imports.rs
+++ b/crates/wasip2/src/imports.rs
@@ -9868,7 +9868,7 @@ mod _rt {
     impl AsI32 for i32 {
         #[inline]
         fn as_i32(self) -> i32 {
-            self as i32
+            self
         }
     }
     impl AsI32 for u32 {
@@ -10013,7 +10013,7 @@ mod _rt {
     impl AsI64 for i64 {
         #[inline]
         fn as_i64(self) -> i64 {
-            self as i64
+            self
         }
     }
     impl AsI64 for u64 {

--- a/crates/wasip2/src/proxy.rs
+++ b/crates/wasip2/src/proxy.rs
@@ -7044,7 +7044,7 @@ mod _rt {
     impl AsI64 for i64 {
         #[inline]
         fn as_i64(self) -> i64 {
-            self as i64
+            self
         }
     }
     impl AsI64 for u64 {
@@ -7067,7 +7067,7 @@ mod _rt {
     impl AsI32 for i32 {
         #[inline]
         fn as_i32(self) -> i32 {
-            self as i32
+            self
         }
     }
     impl AsI32 for u32 {

--- a/crates/wasip3/src/imports.rs
+++ b/crates/wasip3/src/imports.rs
@@ -12800,7 +12800,7 @@ mod _rt {
     impl AsI32 for i32 {
         #[inline]
         fn as_i32(self) -> i32 {
-            self as i32
+            self
         }
     }
     impl AsI32 for u32 {
@@ -12933,7 +12933,7 @@ mod _rt {
     impl AsI64 for i64 {
         #[inline]
         fn as_i64(self) -> i64 {
-            self as i64
+            self
         }
     }
     impl AsI64 for u64 {

--- a/crates/wasip3/src/service.rs
+++ b/crates/wasip3/src/service.rs
@@ -4542,7 +4542,7 @@ mod _rt {
     impl AsI32 for i32 {
         #[inline]
         fn as_i32(self) -> i32 {
-            self as i32
+            self
         }
     }
     impl AsI32 for u32 {
@@ -4601,7 +4601,7 @@ mod _rt {
     impl AsI64 for i64 {
         #[inline]
         fn as_i64(self) -> i64 {
-            self as i64
+            self
         }
     }
     impl AsI64 for u64 {


### PR DESCRIPTION
I believe these casts can be safely removed, as the source type is already the target type.

For reference, these changes were found by an optimizer developed as a research project.

CC @nunoplopes